### PR TITLE
Accepting numpy arrays in object detectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,7 @@ contain:
   string containing the raw, undecoded, image file bytes (`'bytes'`)
   or the decompressed image data represented as a nested python list,
   numpy array, or TensorFlow tensor of pixel values
-  (`'pixel_values'`).  Note that this last option is only available
-  for models that take a single image as input, and the pixel array
-  must be resized to the expected resolution given in the model; when
-  using the other two options, images are resized as they are
-  decompressed.
+  (`'pixel_values'`).
 
 - `iou_threshold`: A threshold indicating the amount of overlap boxes
   predicting the same class should have before they are considered to

--- a/sensenet/__init__.py
+++ b/sensenet/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.2.5'
+__version__ = '0.2.6'
 __tree_ext_prefix__ = 'bigml_tf_tree'

--- a/sensenet/models/bounding_box.py
+++ b/sensenet/models/bounding_box.py
@@ -104,8 +104,7 @@ def box_detector(model, input_settings):
     reader = BoundingBoxImageReader(network, settings)
 
     if settings.input_image_format == 'pixel_values':
-        image_shape = get_image_shape(model)
-        image_input = kl.Input(image_shape[1:], dtype=tf.float32, name='image')
+        image_input = kl.Input((None, None, 3), dtype=tf.float32, name='image')
         raw_image, original_shape = reader(image_input)
     else:
         image_input = kl.Input((1,), dtype=tf.string, name='image')

--- a/sensenet/models/wrappers.py
+++ b/sensenet/models/wrappers.py
@@ -39,6 +39,10 @@ class ObjectDetector(object):
         elif isinstance(input_data, str):
             prediction = self.predict([[input_data]])
         # Pixel-valued ndarray input
+        elif isinstance(input_data, np.ndarray) and len(input_data.shape) == 3:
+            array = np.expand_dims(input_data, axis=0)
+            prediction = self.predict(array)
+        # Something else (tf.tensor or python list)
         else:
             prediction = self.predict(input_data)
 

--- a/sensenet/models/wrappers.py
+++ b/sensenet/models/wrappers.py
@@ -1,3 +1,6 @@
+import sensenet.importers
+np = sensenet.importers.import_numpy()
+
 from sensenet.accessors import is_yolo_model
 from sensenet.load import load_points
 from sensenet.models.bounding_box import box_detector


### PR DESCRIPTION
The object detection wrapper had trouble with arbitrarily-sized 3d numpy arrays as input, as discovered by @kendian.  This fixes that problem for the object detector, but I think the classifier wrapper might still have the same problem, which we will deal with in the "future" (but just so you're aware, @unmonoqueteclea)