### PR TITLE
More Input Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ settings which may contain:
   will have the effect of more (possibly spurious) boxes identified in
   each input image.
 
+- `color_space`: A string which is One of `['rgb', 'rgba', 'bgr',
+  'bgra']`.  The first three letters give the order of the color
+  channels (red, blue, and green) in the input tensors that will be
+  passed to the model.  The final presense or absence of an `'a'`
+  indicates that an alpha channel will be present (which will be
+  ignored).  This can be useful to match the color space of the output
+  model to that provided by another library, such as open CV.  Note
+  that TensorFlow uses RGB ordering by default, and all files read by
+  tensorflow are automatically read as RGB files.  This argument is
+  generally only necessary if `input_image_format` is
+  `'pixel_values'`, and will possibly break predictions if specified
+  when the input is a file.
+
 - `image_path_prefix`: A string directory indicating the path where
   images are to be found for image predictions.  When an image path is
   passed at prediction time, this string is prepended to the given
@@ -55,6 +68,22 @@ settings which may contain:
 - `max_objects`: The maximum number of bounding boxes to return for
   each image.  The default is 32.
 
+- `rescale_type`: A string which is one of `['warp', 'pad', 'crop']`.
+  If `'warp'`, input images are scaled to the input dimensions
+  specified in the network, and their aspect ratios are *not*
+  preserved.  If `'pad'`, the image is resized to the smallest
+  dimensions such that the image fits into the input dimensions of the
+  network, then padded with constant pixels either below or to the
+  right to create an appropriately sized image.  For example, if the
+  input dimesions of the network are 100 x 100, and we attempt to
+  classify a 300 x 600 image, the image is first rescaled to 50 x 100
+  (preserving its aspect ratio) then padded on the right to create a
+  100 x 100 image.  If `'crop'`, the image is resized to the smallest
+  dimension such that the input dimensions fit in the image, then the
+  image is centrally cropped to make the specified sizes.  Using the
+  sizes in previous example, the image would be rescaled to 100 x 200
+  (preserving its aspect ratio) then cropped by 50 pixels on the top
+  and bottom to create a 100 x 100 image.
 
 ## Usage
 

--- a/sensenet/accessors.py
+++ b/sensenet/accessors.py
@@ -20,6 +20,14 @@ def get_image_shape(anobject):
 
     return [None, ishape[1], ishape[0], ishape[2]]
 
+def get_image_tensor_shape(settings):
+    if settings.color_space and settings.color_space.lower()[-1] == 'a':
+        nchannels = 4
+    else:
+        nchannels = 3
+
+    return (None, None, nchannels)
+
 def get_output_exposition(model):
     if 'output_exposition' in model:
         return model['output_exposition']

--- a/sensenet/constants.py
+++ b/sensenet/constants.py
@@ -32,6 +32,11 @@ IMAGE_STANDARDIZERS = {
     'channelwise_standardizing': (TORCH_MEAN, TORCH_STD)
 }
 
+# Ways to scale image to input size
+WARP = 'warp'
+PAD = 'pad'
+PAD_OR_CROP = 'pad_or_crop'
+
 # Default parameters for YOLO bounding box detection
 MAX_OBJECTS = 32
 SCORE_THRESHOLD = 0.5

--- a/sensenet/constants.py
+++ b/sensenet/constants.py
@@ -35,7 +35,7 @@ IMAGE_STANDARDIZERS = {
 # Ways to scale image to input size
 WARP = 'warp'
 PAD = 'pad'
-PAD_OR_CROP = 'pad_or_crop'
+CROP = 'crop'
 
 # Default parameters for YOLO bounding box detection
 MAX_OBJECTS = 32

--- a/sensenet/models/bounding_box.py
+++ b/sensenet/models/bounding_box.py
@@ -3,9 +3,10 @@ np = sensenet.importers.import_numpy()
 tf = sensenet.importers.import_tensorflow()
 kl = sensenet.importers.import_keras_layers()
 
-from sensenet.constants import MAX_OBJECTS
+from sensenet.constants import PAD, MAX_OBJECTS
 from sensenet.constants import SCORE_THRESHOLD, IGNORE_THRESHOLD, IOU_THRESHOLD
 from sensenet.accessors import number_of_classes, get_image_shape
+from sensenet.accessors import get_image_tensor_shape
 from sensenet.layers.yolo import YoloTrunk, YoloBranches
 from sensenet.models.settings import ensure_settings
 from sensenet.preprocess.image import BoundingBoxImageReader, ImageLoader
@@ -108,6 +109,7 @@ class BoxLocator(tf.keras.layers.Layer):
 
 def box_detector(model, input_settings):
     settings = ensure_settings(input_settings)
+    settings.rescale_type = PAD
 
     network = model['image_network']
     reader = BoundingBoxImageReader(network, settings)
@@ -119,7 +121,8 @@ def box_detector(model, input_settings):
     locator = BoxLocator(network, nclasses, settings)
 
     if settings.input_image_format == 'pixel_values':
-        image_input = kl.Input((None, None, 3), dtype=tf.float32, name='image')
+        image_shape = get_image_tensor_shape(settings)
+        image_input = kl.Input(image_shape, dtype=tf.float32, name='image')
     else:
         image_input = kl.Input((1,), dtype=tf.string, name='image')
 

--- a/sensenet/models/deepnet.py
+++ b/sensenet/models/deepnet.py
@@ -2,8 +2,9 @@ import sensenet.importers
 tf = sensenet.importers.import_tensorflow()
 kl = sensenet.importers.import_keras_layers()
 
-from sensenet.constants import IMAGE_PATH, NUMERIC, CATEGORICAL
 from sensenet.accessors import get_image_shape, get_output_exposition
+from sensenet.accessors import get_image_tensor_shape
+from sensenet.constants import IMAGE_PATH, NUMERIC, CATEGORICAL
 from sensenet.layers.construct import layer_sequence, tree_preprocessor
 from sensenet.layers.utils import propagate
 from sensenet.load import load_points
@@ -19,7 +20,8 @@ def instantiate_inputs(model, settings):
 
     if ncols == 1 and settings.input_image_format == 'pixel_values':
         assert ptypes[0] == IMAGE_PATH
-        return kl.Input((None, None, 3), dtype=tf.float32, name='image')
+        image_shape = get_image_tensor_shape(settings)
+        return kl.Input(image_shape, dtype=tf.float32, name='image')
     else:
         return {
             'numeric': kl.Input((ncols,), dtype=tf.float32, name='numeric'),

--- a/sensenet/models/settings.py
+++ b/sensenet/models/settings.py
@@ -1,12 +1,19 @@
+from sensenet.constants import WARP, PAD, PAD_OR_CROP
+
+COLOR_SPACES = ['bgr', 'rgb', 'bgra', 'rgba']
+COLOR_SPACES += [f.upper() for f in COLOR_SPACES]
+
 OPTIONAL = {
     'bounding_box_threshold': [1e-8, 1.0],
+    'color_space': COLOR_SPACES,
     'image_path_prefix': str,
     'input_image_format': str,
     'iou_threshold': [1e-8, 1.0],
     'load_pretrained_weights': bool,
     'max_objects': int,
     'output_unfiltered_boxes': bool,
-    'regression_normalize': bool
+    'regression_normalize': bool,
+    'rescale_type': [WARP, PAD, PAD_OR_CROP]
 }
 
 REQUIRED = {}

--- a/sensenet/models/settings.py
+++ b/sensenet/models/settings.py
@@ -1,4 +1,4 @@
-from sensenet.constants import WARP, PAD, PAD_OR_CROP
+from sensenet.constants import WARP, PAD, CROP
 
 COLOR_SPACES = ['bgr', 'rgb', 'bgra', 'rgba']
 COLOR_SPACES += [f.upper() for f in COLOR_SPACES]
@@ -13,7 +13,7 @@ OPTIONAL = {
     'max_objects': int,
     'output_unfiltered_boxes': bool,
     'regression_normalize': bool,
-    'rescale_type': [WARP, PAD, PAD_OR_CROP]
+    'rescale_type': [WARP, PAD, CROP]
 }
 
 REQUIRED = {}

--- a/sensenet/models/wrappers.py
+++ b/sensenet/models/wrappers.py
@@ -121,6 +121,10 @@ class Deepnet(object):
             else:
                 # Properly wrapped instance
                 return self.predict(input_data)
+        # Pixel-valued ndarray input image; will only work for single images
+        elif isinstance(input_data, np.ndarray) and len(input_data.shape) == 3:
+            array = np.expand_dims(input_data, axis=0)
+            return self.predict(array)
         # Single image path or text field
         elif isinstance(input_data, str):
             return self.predict([[input_data]])

--- a/sensenet/models/wrappers.py
+++ b/sensenet/models/wrappers.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 
 from sensenet.accessors import is_yolo_model, get_output_exposition
+from sensenet.constants import PAD
 from sensenet.load import load_points
 from sensenet.models.bounding_box import box_detector
 from sensenet.models.deepnet import deepnet_model
@@ -23,7 +24,7 @@ def get_tf_model(model_or_spec, settings):
     """
     if isinstance(model_or_spec, tf.keras.Model):
         return model_or_spec
-    elif isinstance(model_or_spec, (Deepnet, ObjectDetector)):
+    elif isinstance(model_or_spec,(Deepnet, ObjectDetector)):
         return model_or_spec._model
     else:
         if isinstance(model_or_spec, dict):
@@ -124,7 +125,7 @@ class Deepnet(object):
         # Pixel-valued ndarray input image; will only work for single images
         elif isinstance(input_data, np.ndarray) and len(input_data.shape) == 3:
             array = np.expand_dims(input_data, axis=0)
-            return self.predict(array)
+            return self._model.predict(array)
         # Single image path or text field
         elif isinstance(input_data, str):
             return self.predict([[input_data]])

--- a/sensenet/preprocess/image.py
+++ b/sensenet/preprocess/image.py
@@ -3,7 +3,7 @@ import os
 import sensenet.importers
 tf = sensenet.importers.import_tensorflow()
 
-from sensenet.constants import IMAGE_STANDARDIZERS, WARP, PAD, PAD_OR_CROP
+from sensenet.constants import IMAGE_STANDARDIZERS, WARP, PAD, CROP
 from sensenet.accessors import get_image_shape
 from sensenet.layers.utils import constant, propagate
 from sensenet.layers.construct import layer_sequence
@@ -71,7 +71,7 @@ def rescale(settings, target_shape, image):
 
     if settings.rescale_type is None or settings.rescale_type == WARP:
         new_image = tf.image.resize(image, target_dims, method='nearest')
-    elif settings.rescale_type in [PAD, PAD_OR_CROP]:
+    elif settings.rescale_type in [PAD, CROP]:
         new_image = resize_with_crop_or_pad(settings, target_dims, image)
     else:
         raise ValueError('Rescale type %s unknown' % settings.rescale_type)
@@ -86,8 +86,8 @@ def rescale(settings, target_shape, image):
     elif image.shape[-1] != 3:
         raise ValueError('Number of color channels is %d' % image.shape[-1])
 
-    if settings.color_space and settings.color_space.lower().startswith('rgb'):
-        return tf.reverse(new_image, axis[-1])
+    if settings.color_space and settings.color_space.lower().startswith('bgr'):
+        return tf.reverse(new_image, axis=[-1])
     else:
         return new_image
 

--- a/tests/test_construct.py
+++ b/tests/test_construct.py
@@ -5,7 +5,8 @@ kl = sensenet.importers.import_keras_layers()
 
 from sensenet.layers.block import BlockLayer
 from sensenet.layers.construct import layer_sequence
-from sensenet.preprocess.image import get_image_reader_fn
+from sensenet.models.settings import Settings
+from sensenet.preprocess.image import make_image_reader
 
 from .utils import make_model
 
@@ -162,7 +163,8 @@ def test_dropblock():
                     'rate': 0.1}]
     }
 
-    reader = get_image_reader_fn(image_shape, 'file', 'tests/data/images')
+    settings = Settings({'image_path_prefix': 'tests/data/images'})
+    reader = make_image_reader(settings, image_shape, False)
     lseq = layer_sequence(network)
     model = make_model(lseq, image_shape[1:])
     pizzas = ['pizza_people.jpg'] * 16

--- a/tests/test_pretrained.py
+++ b/tests/test_pretrained.py
@@ -40,6 +40,13 @@ def reader_for_network(network_name, additional_settings):
     image_shape = get_image_shape(get_pretrained_network(network_name))
     return make_image_reader(Settings(extras), image_shape, False)
 
+def check_image_prediction(prediction, index, pos_threshold, neg_threshold):
+    for i, p in enumerate(prediction.flatten().tolist()):
+        if i == index:
+            assert p > pos_threshold, str((i, p))
+        else:
+            assert p < neg_threshold, str((i, p))
+
 def classify(network_name, accuracy_threshold):
     pixel_input = {'input_image_format': 'pixel_values'}
 
@@ -66,11 +73,7 @@ def classify(network_name, accuracy_threshold):
         pixel_pred = pixel_model.predict(img_px)
 
         for pred in [file_pred, pixel_pred]:
-            for i, p in enumerate(pred.flatten().tolist()):
-                if i == cidx:
-                    assert p > accuracy_threshold, str((i, p))
-                else:
-                    assert p < 0.02, str((i, p))
+            check_image_prediction(pred, cidx, accuracy_threshold, 0.02)
 
     outputs = ex_mod(load_points(preprocessors, [['dog.jpg'], ['bus.jpg']]))
     assert outputs.shape == (2, noutputs)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,0 +1,69 @@
+import sensenet.importers
+np = sensenet.importers.import_numpy()
+tf = sensenet.importers.import_tensorflow()
+
+import os
+import json
+import gzip
+
+from PIL import Image
+
+from sensenet.models.wrappers import create_model
+
+from .utils import TEST_DATA_DIR, TEST_IMAGE_DATA
+from .test_pretrained import check_image_prediction
+
+BUS_INDEX = 779
+BUS_PATH = os.path.join(TEST_IMAGE_DATA, 'bus.jpg')
+
+MOBILENET_PATH = os.path.join(TEST_DATA_DIR, 'mobilenetv2.json.gz')
+
+def make_mobilenet(settings):
+    with gzip.open(MOBILENET_PATH, 'rb') as fin:
+        network = json.load(fin)
+
+    return create_model(network, settings)
+
+def check_pixels_and_file(settings, pos_threshold, neg_threshold):
+    pix_settings = dict(settings)
+    pix_settings['input_image_format'] = 'pixel_values'
+    pix_model = make_mobilenet(pix_settings)
+
+    file_settings = dict(settings)
+    file_settings['input_image_format'] = 'file'
+    file_model = make_mobilenet(file_settings)
+
+    image_pixels = np.array(Image.open(BUS_PATH))
+
+    if pix_settings.get('color_space', '').endswith('a'):
+        new_pixels = np.zeros((image_pixels.shape[0], image_pixels.shape[1], 4))
+        new_pixels[:,:,:3] = image_pixels
+        image_pixels = new_pixels
+
+    pixel_pred = pix_model(image_pixels)
+    file_pred = file_model(BUS_PATH)
+
+    diffs = np.abs(pixel_pred - file_pred)
+    assert np.all(diffs < 1e-3), np.max(diffs)
+
+    for pred in [pixel_pred, file_pred]:
+        check_image_prediction(pred, BUS_INDEX, pos_threshold, neg_threshold)
+
+    return pixel_pred
+
+def test_channel_order():
+    for space, pos, neg in [('rgb', 0.98, 0.02), ('bgr', 0.11, 0.5)]:
+        settings = {'color_space': space}
+        no_alpha = check_pixels_and_file(settings, pos, neg)
+
+        settings = {'color_space': space + 'a'}
+        alpha = check_pixels_and_file(settings, pos, neg)
+
+        assert np.all(np.abs(alpha - no_alpha) < 1e-4)
+
+def test_cropping():
+    for rt, threshold in [('warp', 0.98), ('pad', 0.96), ('crop', 0.97)]:
+        settings = {'rescale_type': rt}
+        pred = check_pixels_and_file(settings, threshold, 0.02)
+
+        assert threshold < pred[0, BUS_INDEX] < threshold + 0.01


### PR DESCRIPTION
@kendian - This should fix the issue with not accepting numpy.ndarrays for classifiers.

@sdesimone / @unmonoqueteclea - This allows you to export a model that will crop or pad inputs to reach the desired size for classifiers, and also allows you to specify the input color space for pixel tensors (see the doc). @sdesimone - I did a bit more digging and found that it's open CV, not tensorflow that uses BGR as the default input space.  TF expects RGB tensors.  Sorry for the noise.