### PR TITLE
Integration Nits

### DIFF
--- a/sensenet/__init__.py
+++ b/sensenet/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.4.3'
+__version__ = '0.4.4'
 __tree_ext_prefix__ = 'bigml_tf_tree'

--- a/sensenet/layers/dropblock.py
+++ b/sensenet/layers/dropblock.py
@@ -8,6 +8,9 @@ class DropBlock2D(tf.keras.layers.Layer):
         assert 0 < rate < 1
 
         self._seed = seed
+        self._rate = rate
+        self._size = block_size
+
         self._keep_prob = tf.constant(1 - rate, dtype=tf.float32)
         self._block_size = tf.constant(block_size, dtype=tf.int32)
 
@@ -64,3 +67,10 @@ class DropBlock2D(tf.keras.layers.Layer):
         block_mask = tf.nn.max_pool(mask, block_shape, [1, 1, 1, 1], 'SAME')
 
         return 1 - block_mask
+
+    def get_config(self):
+        return {
+            'rate': self._rate,
+            'block_size': self._size,
+            'seed': self._seed
+        }

--- a/sensenet/layers/extract.py
+++ b/sensenet/layers/extract.py
@@ -134,6 +134,7 @@ def zero_pad(config, layer):
 
 LAYER_EXTRACTORS = {
     'Activation': activation,
+    'AlphaDropout': dropout,
     'Add': add,
     'BatchNormalization': batchnorm,
     'Concatenate': concat,
@@ -141,7 +142,7 @@ LAYER_EXTRACTORS = {
     'Dense': dense,
     'DepthwiseConv2D': depthwise_conv_2d,
     'Dropout': dropout,
-    'AlphaDropout': dropout,
+    'DropBlock2D': dropout,
     'GlobalAveragePooling2D': global_avg_pool,
     'GlobalMaxPooling2D': global_max_pool,
     'Lambda': lamda,

--- a/sensenet/models/wrappers.py
+++ b/sensenet/models/wrappers.py
@@ -87,7 +87,7 @@ class SaveableModel(object):
                 json.dump(attributes, fout)
 
             bundle_file = write_bundle(model_path)
-            os.rename(bundle_file, out_path)
+            shutil.copy(bundle_file, out_path)
 
             if tfjs_path:
                 self.write_tfjs_files(model_path, tfjs_path)

--- a/sensenet/preprocess/image.py
+++ b/sensenet/preprocess/image.py
@@ -106,10 +106,12 @@ def rescale(settings, target_shape, image):
     elif image.shape[-1] != 3:
         raise ValueError('Number of color channels is %d' % new_image.shape[-1])
 
+    height, width = target_shape[1], target_shape[2]
+
     if len(image.shape) == 4:
-        new_image.set_shape([None, None, None, 3])
+        new_image.set_shape([None, height, width, 3])
     elif len(image.shape) == 3:
-        new_image.set_shape([None, None, 3])
+        new_image.set_shape([height, width, 3])
     else:
         raise ValueError('Image tensor is rank %d' % len(image.shape))
 


### PR DESCRIPTION
We weren't handling dropblock layers properly at serialization and also the /tmp and /volatile/tmp volumes are on different devices in prod, and so os.rename fails.