### PR TITLE
fix: pin protobuf version during build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires=[
+  "protobuf>=3.20,<3.21",
   "tensorflow-macos <2.9,>=2.8;sys_platform=='darwin' and platform_machine=='arm64'",
   "tensorflow-aarch64 <2.9,>=2.8;sys_platform=='linux' and platform_machine=='aarch64'",
   "tensorflow <2.9,>=2.8;platform_machine!='arm64' and platform_machine!='aarch64'",

--- a/sensenet/__init__.py
+++ b/sensenet/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 __tree_ext_prefix__ = "bigml_tf_tree"

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ TF_VER = ">=2.8,<2.9"
 
 deps = [
     "pillow>=9.1,<9.2",
+    # Until we upgrade tensorflow, we need to pin this version
+    "protobuf<3.21",
 ]
 
 # The installation of `tensorflow-gpu` should be specific to canonical


### PR DESCRIPTION
Due to a breaking change in protobuf, we need to make sure to not use
a too recent version of the library when installing "older" versions
of tensorflow.
This was documented [here](https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates)

This was breaking the installation process, at least on mac m1. 
If someone can test it on a different arch, we can make sure this works on other archs as well.