### PR TITLE
chore: ensure Github actions run tests in Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.9,3.10,3.11]
+        python: ['3.9','3.10','3.11']
     env:
         TF_CPP_MIN_LOG_LEVEL: 2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,18 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.9]
+        python: [3.9,3.10,3.11]
     env:
         TF_CPP_MIN_LOG_LEVEL: 2
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
-
-    - name: Install test dependencies
-      run: |
-        pip install pytest
-        pip install "scikit-learn>=1.0,<1.1"
+      uses: actions/checkout@v4
 
     - name: Install sensenet
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,4 +26,4 @@ jobs:
 
     - name: Run sensenet tests
       run: |
-        pytest -sv
+        pytest -xsv

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,22 +8,24 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      CIBW_ARCHS_MACOS: x86_64 arm64
-      CIBW_ARCHS_LINUX: auto aarch64
-      CIBW_BUILD: cp38-* cp39-* cp310-*
+      CIBW_BUILD: cp310-* cp311-*  # build for Python 3.10 and Python 3.11
       CIBW_BUILD_VERBOSITY: 1
-      # Right now, cp310 isn't building properly on aarch64
+      # right now, cp310 isn't building properly on aarch64
       CIBW_SKIP: cp36-* *-win32 *-manylinux_i686 pp* *musllinux* cp310-*_aarch64
-      CIBW_BEFORE_ALL_LINUX: 'POLICY_JSON=$(find / -name manylinux-policy.json); sed -i "s/libresolv.so.2\"/libresolv.so.2\",\"libtensorflow_framework.so.1\", \"libtensorflow_framework.so.2\"/g" $POLICY_JSON'
+      CIBW_ARCHS_MACOS: x86_64 arm64  # arm64 for Apple Sillicon support
+      CIBW_ARCHS_LINUX: auto aarch64  # allowing arm processors
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: 'delocate-listdeps {wheel} && delocate-wheel --require-archs {delocate_archs} --ignore-missing-dependencies -w {dest_dir} {wheel}'
-      CIBW_TEST_REQUIRES: pytest scikit-learn
+      # not needed because those packages are already in package requirements
+      # CIBW_TEST_REQUIRES: pytest scikit-learn
       CIBW_TEST_COMMAND: 'cd {package} && pytest -sv tests/test_tree.py && pytest -sv tests/test_wrappers.py'
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # we will be able to include ubuntu-latest when we fix this issue
+        # https://github.com/bigmlcom/sensenet/issues/37
+        os: [macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
@@ -32,9 +34,9 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.4.0
+        uses: pypa/cibuildwheel@v2.16.5
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
@@ -42,12 +44,12 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ input and can output the following formats:
   allows lightweight prediction on mobile devices.
 
 - `tfjs` exports the model to the format read by Tensorflow JS to do
-  predictions in the browser and server-side in node.js.
+  predictions in the browser and server-side in node.js. The library
+  needed to do this export, `tensorflowjs`, is not available in all
+  architectures, so this feature may not always work.
 
 - `smbundle` exports the model to a (proprietary) lightweight wrapper
   around the TensorFlow SavedModel format.  The generated file is a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,6 @@ requires=[
 [tool.black]
 line-length = 80
 target-version = ['py311']
+
+[tool.cibuildwheel.linux]
+repair-wheel-command = "auditwheel repair --exclude libtensorflow_framework.so.2 --exclude libtensorflow_framework.so.1 --exclude libtensorflow_framework.so -w {dest_dir} {wheel}"

--- a/sensenet/__init__.py
+++ b/sensenet/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 __tree_ext_prefix__ = "bigml_tf_tree"

--- a/sensenet/importers.py
+++ b/sensenet/importers.py
@@ -10,6 +10,7 @@ import warnings
 
 from sensenet import __tree_ext_prefix__
 
+logger = logging.getLogger(__name__)
 logging.getLogger("tensorflow").setLevel(logging.ERROR)
 
 warnings.filterwarnings("ignore", message=".*binary incompatibility.*")
@@ -33,7 +34,10 @@ with warnings.catch_warnings():
     # but it is not mandatory for Sensenet to work
     try:
         import tensorflowjs
-    except:  # noqa: E722
+    except Exception as e:  # noqa: E722
+        logger.info(
+            f"tensorflowjs not found, you can't export models to JS: {e}"
+        )
         tensorflowjs = None
 
 bigml_tf_module = None

--- a/sensenet/importers.py
+++ b/sensenet/importers.py
@@ -2,11 +2,11 @@
 various messages on import.
 
 """
-import sys
-import os
-import logging
-import warnings
 import glob
+import logging
+import os
+import sys
+import warnings
 
 from sensenet import __tree_ext_prefix__
 
@@ -19,7 +19,7 @@ warnings.filterwarnings("ignore", message=".*Pillow 10.*Resampling.*")
 warnings.filterwarnings("ignore", message=".*distutils Version classes.*")
 
 
-import numpy
+import numpy  # noqa: E402
 
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", message=".*as a synonym of type.*")
@@ -27,11 +27,13 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", message=".*details.*")
 
     import tensorflow
-    import tensorflow.keras.layers
+    import tensorflow.keras.layers  # type: ignore
 
+    # tensoflowjs is not available in all architectures (see setup.py)
+    # but it is not mandatory for Sensenet to work
     try:
         import tensorflowjs
-    except:
+    except:  # noqa: E722
         tensorflowjs = None
 
 bigml_tf_module = None

--- a/sensenet/models/wrappers.py
+++ b/sensenet/models/wrappers.py
@@ -1,3 +1,4 @@
+# flake8: noqa: E402
 import sensenet.importers
 
 np = sensenet.importers.import_numpy()
@@ -7,12 +8,10 @@ tfjs = sensenet.importers.import_tfjs()
 import json
 import os
 import shutil
-import tempfile
 import sys
+import tempfile
 import warnings
-
 from contextlib import contextmanager
-from PIL import Image
 
 import sensenet.accessors as accessors
 import sensenet.constants as constants
@@ -22,6 +21,7 @@ import sensenet.models.bundle as bundle
 import sensenet.models.deepnet as deepnet
 import sensenet.models.image as image
 import sensenet.models.settings as models_settings
+from PIL import Image
 
 SETTINGS_PATH = os.path.join("assets", "settings.json")
 
@@ -64,11 +64,11 @@ class SaveableModel(object):
     def write_tfjs_files(self, model_path, save_path):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message=".*alias for the.*")
-
             with suppress_stdout():
-                tfjs.converters.convert_tf_saved_model(
-                    model_path, save_path, skip_op_check=True
-                )
+                if tfjs:
+                    tfjs.converters.convert_tf_saved_model(
+                        model_path, save_path, skip_op_check=True
+                    )
 
     def save_bundle(self, save_path, tfjs_path=None):
         outdir, model_name = os.path.split(save_path)

--- a/sensenet/models/wrappers.py
+++ b/sensenet/models/wrappers.py
@@ -65,7 +65,7 @@ class SaveableModel(object):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message=".*alias for the.*")
             with suppress_stdout():
-                if tfjs:
+                if tfjs and tfjs.converters:
                     tfjs.converters.convert_tf_saved_model(
                         model_path, save_path, skip_op_check=True
                     )

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,13 @@
 """
 
 import os
-import sys
 import platform
+import sys
+
 import pkg_resources
 import setuptools
 
-from sensenet import __version__, __tree_ext_prefix__
+from sensenet import __tree_ext_prefix__, __version__
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -78,6 +79,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
     package_data={"sensenet": ["sensenet_metadata.json.gz"]},
+    python_requires=">=3.9",
     ext_modules=modules,
     install_requires=deps,
 )

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,21 +1,24 @@
+# flake8:  noqa: E402
 import sensenet.importers
 
 np = sensenet.importers.import_numpy()
 tf = sensenet.importers.import_tensorflow()
 
-import os
-import shutil
 import gzip
 import json
-
-from PIL import Image
+import os
+import shutil
 
 from sensenet.constants import WARP
-from sensenet.models.wrappers import Deepnet, ObjectDetector
-from sensenet.models.wrappers import convert, tflite_predict
+from sensenet.models.wrappers import (
+    Deepnet,
+    ObjectDetector,
+    convert,
+    tflite_predict,
+)
 
-from .utils import TEST_DATA_DIR, TEST_IMAGE_DATA
 from .test_pretrained import create_image_model
+from .utils import TEST_DATA_DIR, TEST_IMAGE_DATA
 
 MOBILENET_PATH = os.path.join(TEST_DATA_DIR, "mobilenetv2.json.gz")
 TEST_SAVE_MODEL = os.path.join(TEST_DATA_DIR, "test_model_save")
@@ -118,8 +121,7 @@ def test_all_conversions():
     for aformat in ["tflite", "tfjs", "smbundle", "h5"]:
         outpath = TEST_SAVE_MODEL + "." + aformat
         convert(jmodel, None, outpath, aformat)
-
         if aformat == "tfjs":
-            shutil.rmtree(outpath)
+            shutil.rmtree(outpath, ignore_errors=True)
         else:
             os.remove(outpath)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,21 +1,21 @@
-import os
+# flake8: noqa: E402
 import json
-import time
-import pytest
+import os
 
+import pytest
 import sensenet.importers
 
 np = sensenet.importers.import_numpy()
 tf = sensenet.importers.import_tensorflow()
 
-from sensenet.constants import NUMERIC, CATEGORICAL
-from sensenet.preprocess.preprocessor import Preprocessor
+from sensenet.constants import CATEGORICAL, NUMERIC
 from sensenet.layers.construct import remove_weights
 from sensenet.layers.legacy import legacy_convert
 from sensenet.layers.tree import ForestPreprocessor
 from sensenet.load import load_points
-from sensenet.models.wrappers import create_model
 from sensenet.models.settings import Settings
+from sensenet.models.wrappers import create_model
+from sensenet.preprocess.preprocessor import Preprocessor
 
 from .utils import TEST_DATA_DIR, read_regression
 
@@ -73,6 +73,7 @@ def round_trip(settings, wrapper):
     # print('save weights: %.2f' % (time.time() - start))
     # start = time.time()
     new_wrapper = create_model(short, EXTRA_PARAMS)
+    assert new_wrapper
     # print('recreate model: %.2f' % (time.time() - start))
     # start = time.time()
     new_wrapper._model.load_weights(TEMP_WEIGHTS)


### PR DESCRIPTION
We didn't update the Python versions where we want tests to run. They were just running in `Python 3.9`. I also removed the `Install Test Dependencies` section, because those two dependencies are already part of the package requirements list.

I am not sure if this PR will trigger the new workflow with the new versions, or we will have to merge it first and it will run in the next PR. Anyways, I found that wheels build process failed in the previous PR. We will need to check why (I still don't know), because wheels make that Python packages installations much faster and stable.

Furthermore, I am seeing a strange error locally in a test. I want to check tests logs here before starting to work on it. 

cc @mmerce @jaor 